### PR TITLE
Updated enable/disable resizable methods to check for data('ui-dragga…

### DIFF
--- a/source/stable/jquery.layout.js
+++ b/source/stable/jquery.layout.js
@@ -4644,8 +4644,9 @@ $.fn.layout = function (opts) {
 		if (!isInitialized()) return;
 		var	pane = evtPane.call(this, evt_or_pane)
 		,	$R	= $Rs[pane]
+		,	isSlidable = $R && ($R.data('draggable') || $R.data('ui-draggable')) // jquery-ui 1.10.2+, uses 'ui-draggable'
 		;
-		if (!$R || !$R.data('draggable')) return;
+		if (!isSlidable) return;
 		options[pane].slidable = true; 
 		if (state[pane].isClosed)
 			bindStartSlidingEvents(pane, true);
@@ -4679,8 +4680,9 @@ $.fn.layout = function (opts) {
 		var	pane = evtPane.call(this, evt_or_pane)
 		,	$R	= $Rs[pane]
 		,	o	= options[pane]
+		,	isResizable = $R && ($R.data('draggable') || $R.data('ui-draggable')) // jquery-ui 1.10.2+, uses 'ui-draggable'
 		;
-		if (!$R || !$R.data('draggable')) return;
+		if (!isResizable) return;
 		o.resizable = true; 
 		$R.draggable("enable");
 		if (!state[pane].isClosed)
@@ -4694,8 +4696,9 @@ $.fn.layout = function (opts) {
 		if (!isInitialized()) return;
 		var	pane = evtPane.call(this, evt_or_pane)
 		,	$R	= $Rs[pane]
+		,	isResizable = $R && ($R.data('draggable') || $R.data('ui-draggable')) // jquery-ui 1.10.2+, uses 'ui-draggable'
 		;
-		if (!$R || !$R.data('draggable')) return;
+		if (!isResizable) return;
 		options[pane].resizable = false; 
 		$R	.draggable("disable")
 			.css("cursor", "default")


### PR DESCRIPTION
…ble') also, which is the new way since jquery-ui 1.10.2
